### PR TITLE
add 保研经验贴/学校相关 to astro.config.mjs

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -42,6 +42,7 @@ export default defineConfig({
 					label: '保研经验贴',
 					items: [
 						{ label: '总览', slug: '保研经验贴/总览' },
+						{ label: '学校相关', slug: '保研经验贴/学校相关' },
 						{ label: '2024年保研总结贴', slug: '保研经验贴/2024年' },
 						{ label: '2023年保研总结贴', slug: '保研经验贴/2023年' },
 						{ label: '2022年保研总结贴', slug: '保研经验贴/2022年' },


### PR DESCRIPTION
页面左侧目录“保研经验贴”一栏缺少跳转至“学校相关”的超链接，可以跳转至 [https://csbaoyan.top/保研经验贴/学校相关](https://csbaoyan.top/%E4%BF%9D%E7%A0%94%E7%BB%8F%E9%AA%8C%E8%B4%B4/%E5%AD%A6%E6%A0%A1%E7%9B%B8%E5%85%B3/)